### PR TITLE
Remove animation from page__hero--overlay image

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -111,8 +111,7 @@
   position: relative;
   margin-bottom: 2em;
   @include clearfix;
-  animation: intro 0.3s both;
-  animation-delay: 0.25s;
+  background-color: #43b6f6;
 
   &--overlay {
     position: relative;


### PR DESCRIPTION
The animation i.e. the intro delay of 0.3s on the `page__hero--overlay` looks as if the image is extremly huge and takes a while to load. During this time we have the white heading text on a white background. To fix this situation for cases in which the 284Kb image really takes a while to load, I changed the background-color of the heading to the blue used in the background-image.