### PR TITLE
Fix dead link

### DIFF
--- a/_pages/learn.md
+++ b/_pages/learn.md
@@ -13,7 +13,7 @@ sidebar:
 You can learn about aim42 in various ways:
 
 
-* Skim over our [whitepaper](), that briefly summarizes aim42.
+* Skim over our [whitepaper](/assets/downloads/AIM42-Whitepaper-v2.0.pdf), that briefly summarizes aim42.
 * Read one of our introductory articles listed under [publications](/publications)
 * Go over one of our presentations, also listed under [publications](/publications)
 


### PR DESCRIPTION
## Description

The `whitepaper` link on the [learn site][] currently does not have an href. This Pull Request adds it.

Thanks for publishing awesome stuff like this!

[learn site]: https://www.aim42.org/learn